### PR TITLE
Bugfix: Parsing Post Video result as json

### DIFF
--- a/lib/dailymotion-api/client.rb
+++ b/lib/dailymotion-api/client.rb
@@ -30,7 +30,7 @@ module DailymotionApi
 
     def post_video(video)
       response = HTTMultiParty.post(@upload_url, body: { file: video })
-      @uploaded_video_url = response.parsed_response["url"]
+      @uploaded_video_url = JSON.parse(response.parsed_response)["url"]
     end
 
     def create_video

--- a/spec/lib/dailymotion-api/client_spec.rb
+++ b/spec/lib/dailymotion-api/client_spec.rb
@@ -35,7 +35,7 @@ describe DailymotionApi::Client do
   describe "#post_video" do
     it "should post the video" do
       client.instance_variable_set(:@upload_url, "upload_url")
-      response = stub("response", parsed_response: { "url" => "video_url" })
+      response = stub("response", parsed_response: "{\"url\":\"video_url\"}")
       HTTMultiParty.should_receive(:post).with("upload_url", body: { file: "video_data" }).and_return(response)
 
       client.post_video("video_data").should == "video_url"


### PR DESCRIPTION
This method returns a json as response and not a hash as expected before.
